### PR TITLE
Feature: backwards compatibility for passport

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -27,7 +27,9 @@ var async = require('async');
  *                 (request, jwt_payload, done_callback) if true.
  */
 function JwtStrategy(options, verify) {
-
+    if (!Array.isArray(options)) {
+        options = [options];
+    }
     passport.Strategy.call(this);
     this.name = 'jwt';
     this._config = new Array(options.length);
@@ -96,9 +98,10 @@ JwtStrategy.JwtVerifier = require('./verify_jwt');
 JwtStrategy.prototype.authenticate = function (req, options) {
     var self = this;
     let fails = [];
+    let errors = [];
     let success = null;
     async.each(self._config, function (configItem, callback) {
-        if(success){
+        if (success) {
             return;
         }
         var token = configItem._jwtFromRequest(req);
@@ -109,31 +112,61 @@ JwtStrategy.prototype.authenticate = function (req, options) {
 
         configItem._secretOrKeyProvider(req, token, function (secretOrKeyError, secretOrKey) {
             if (secretOrKeyError) {
-                fails.push(secretOrKeyError)
-                if(fails.length==self._config.length){
-                    self.fail(fails); 
+                errors.push(secretOrKeyError)
+                if (fails.length + errors.length == self._config.length) {
+                    if (self._config.length == 1) {
+                        errors.length > 0 ? self.error(errors[0]) : self.fail(fails[0]);
+                    }
+
+                    const allErrors = errors.concat(fails);
+                    if (errors.length > 0) {
+                        self.error(allErrors);
+                    }
+                    else {
+                        self.fail(allErrors);
+                    }
                 }
-                } else {
+
+            } else {
                 // Verify the JWT
-                JwtStrategy.JwtVerifier(token, secretOrKey, self._verifOpts, function (jwt_err, payload) {
+                JwtStrategy.JwtVerifier(token, secretOrKey, configItem._verifOpts, function (jwt_err, payload) {
                     if (jwt_err) {
-                        fails.push(jwt_err);
+                        errors.push(jwt_err);
+
+                        if (fails.length + errors.length == self._config.length) {
+                            if (self._config.length == 1) {
+                                if (errors.length > 0) {
+                                     self.error(errors[0]);
+                                }
+                                else {
+                                    self.fail(fails[0]);
+                                    return;
+                                }
+                            }
+
+                            const allErrors = errors.concat(fails);
+                            if (errors.length > 0) {
+                                self.error(allErrors);
+                            }
+                            else {
+                                self.fail(allErrors);
+                            }
+                        }
+
                     } else {
                         // Pass the parsed token to the user, or add errors/fails to the fails array before returning
                         var verified = function (err, user, info) {
                             if (err) {
-                                fails.push(err);
+                                errors.push(err);
                             } else if (!user) {
                                 fails.push(info);
                             } else {
                                 success = info;
                                 return self.success(user, info);
                             }
+                        }
 
-                            if(fails.length==self._config.length){
-                                return self.fail(fails); 
-                            }
-                        };
+                        
 
                         try {
                             if (self._passReqToCallback) {
@@ -149,7 +182,7 @@ JwtStrategy.prototype.authenticate = function (req, options) {
             }
         });
     });
-console.log(`Call to doSomething took ${t1 - t0} milliseconds.`);
+
 };
 
 

--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -116,6 +116,7 @@ JwtStrategy.prototype.authenticate = function (req, options) {
                 if (fails.length + errors.length == self._config.length) {
                     if (self._config.length == 1) {
                         errors.length > 0 ? self.error(errors[0]) : self.fail(fails[0]);
+                        
                     }
 
                     const allErrors = errors.concat(fails);
@@ -140,7 +141,6 @@ JwtStrategy.prototype.authenticate = function (req, options) {
                                 }
                                 else {
                                     self.fail(fails[0]);
-                                    return;
                                 }
                             }
 
@@ -164,6 +164,21 @@ JwtStrategy.prototype.authenticate = function (req, options) {
                                 success = info;
                                 return self.success(user, info);
                             }
+
+                            if (fails.length + errors.length == self._config.length) {
+                                if (self._config.length == 1) {
+                                   return errors.length > 0 ? self.error(errors[0]) : self.fail(fails[0]);
+                                }
+            
+                                const allErrors = errors.concat(fails);
+                                if (errors.length > 0) {
+                                    return self.error(allErrors);
+                                }
+                                else {
+                                    return self.fail(allErrors);
+                                }
+                            }
+            
                         }
 
                         
@@ -182,7 +197,6 @@ JwtStrategy.prototype.authenticate = function (req, options) {
             }
         });
     });
-
 };
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -386,6 +386,11 @@
       "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
       "dev": true
     },
+    "async": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.0.tgz",
+      "integrity": "sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw=="
+    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "sinon": "^1.0.0"
   },
   "dependencies": {
+    "async": "^3.2.0",
     "jsonwebtoken": "^8.2.0",
     "passport-strategy": "^1.0.0"
   }


### PR DESCRIPTION
- Accept a non-array configuration for backwards compatibility
- 3 tests from the original passport-jwt are still failing with Unhandled Promise exceptions, although the tests do return the correct result. Still investigating but merging this as it's better than the previous version on main.